### PR TITLE
infra: pin amneziawg-go to v0.2.17 and amneziawg-tools to v1.0.20260223

### DIFF
--- a/bin/awg-quick
+++ b/bin/awg-quick
@@ -114,6 +114,9 @@ del_if() {
 			cmd ip -6 rule delete table main suppress_prefixlength 0
 		done
 	fi
+	# vpn-deck:patch:begin endpoint-direct-route
+	del_endpoint_direct_route || true
+	# vpn-deck:patch:end endpoint-direct-route
 	cmd ip link delete dev "$INTERFACE"
 }
 
@@ -242,6 +245,61 @@ set_config() {
 	cmd awg setconf "$INTERFACE" <(echo "$WG_CONFIG")
 }
 
+# vpn-deck:patch:begin endpoint-direct-route
+# Adds /32 (or /128) host routes to peer endpoints via the path the kernel
+# would currently use to reach them — *before* the tunnel hijacks routing.
+# Prevents the "tunnel routes its own underlay" loop that occurs when a
+# split-tunnel AllowedIPs CIDR includes the endpoint's IP. Harmless with
+# AllowedIPs=0.0.0.0/0 (more specific than the suppressed default route).
+ENDPOINT_ROUTE_STATE_DIR="/var/run/awg-quick"
+
+_endpoint_route_state_file() {
+	echo "$ENDPOINT_ROUTE_STATE_DIR/${INTERFACE}.endpoint-routes"
+}
+
+set_endpoint_direct_route() {
+	local endpoint host proto mask route_info gw dev state_file
+	state_file="$(_endpoint_route_state_file)"
+	mkdir -p "$ENDPOINT_ROUTE_STATE_DIR" 2>/dev/null || return 0
+	: > "$state_file" 2>/dev/null || return 0
+	while read -r _ endpoint; do
+		[[ $endpoint =~ ^\[?([a-z0-9:.]+)\]?:[0-9]+$ ]] || continue
+		host="${BASH_REMATCH[1]}"
+		if [[ $host == *:* ]]; then
+			proto=-6; mask=128
+		else
+			proto=-4; mask=32
+		fi
+		route_info="$(ip $proto route get "$host" 2>/dev/null | head -n1)"
+		[[ -n $route_info ]] || continue
+		# No "via" means on-link route (LAN endpoint) — nothing to bypass.
+		[[ $route_info =~ via\ ([^ ]+) ]] || continue
+		gw="${BASH_REMATCH[1]}"
+		[[ $route_info =~ dev\ ([^ ]+) ]] || continue
+		dev="${BASH_REMATCH[1]}"
+		# Don't route the endpoint via the tunnel itself.
+		[[ $dev != "$INTERFACE" ]] || continue
+		# Tolerate failure: a missing endpoint-route is preferable to a
+		# fully aborted tunnel start (cleanup of partial state still runs).
+		if cmd ip $proto route replace "$host/$mask" via "$gw" dev "$dev"; then
+			echo "$proto $host/$mask" >> "$state_file"
+		fi
+	done < <(awg show "$INTERFACE" endpoints 2>/dev/null)
+	[[ -s $state_file ]] || rm -f "$state_file"
+}
+
+del_endpoint_direct_route() {
+	local proto cidr state_file
+	state_file="$(_endpoint_route_state_file)"
+	[[ -f $state_file ]] || return 0
+	while read -r proto cidr; do
+		[[ -n $proto && -n $cidr ]] || continue
+		cmd ip $proto route del "$cidr" 2>/dev/null || true
+	done < "$state_file"
+	rm -f "$state_file"
+}
+# vpn-deck:patch:end endpoint-direct-route
+
 save_config() {
 	local old_umask new_config current_config address cmd
 	[[ $(ip -all -brief address show dev "$INTERFACE") =~ ^$INTERFACE\ +\ [A-Z]+\ +(.+)$ ]] || true
@@ -326,6 +384,11 @@ cmd_up() {
 	done
 	set_mtu_up
 	set_dns
+	# vpn-deck:patch:begin endpoint-direct-route
+	# Must run *before* add_route so the kernel still sees the original
+	# (pre-tunnel) path to each peer endpoint via `ip route get`.
+	set_endpoint_direct_route
+	# vpn-deck:patch:end endpoint-direct-route
 	for i in $(while read -r _ i; do for i in $i; do [[ $i =~ ^[0-9a-z:.]+/[0-9]+$ ]] && echo "$i"; done; done < <(awg show "$INTERFACE" allowed-ips) | sort -nr -k 2 -t /); do
 		add_route "$i"
 	done

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -4,10 +4,13 @@ RUN pacman -Sy --noconfirm && \
     pacman -S --noconfirm go git base-devel libmnl && \
     pacman -Scc --noconfirm
 
-RUN git clone --depth 1 https://github.com/amnezia-vpn/amneziawg-go.git /tmp/amneziawg-go && \
+ARG AMNEZIAWG_GO_REF=v0.2.17
+ARG AMNEZIAWG_TOOLS_REF=v1.0.20260223
+
+RUN git clone --depth 1 --branch "${AMNEZIAWG_GO_REF}" https://github.com/amnezia-vpn/amneziawg-go.git /tmp/amneziawg-go && \
     make -C /tmp/amneziawg-go
 
-RUN git clone --depth 1 https://github.com/amnezia-vpn/amneziawg-tools.git /tmp/amneziawg-tools && \
+RUN git clone --depth 1 --branch "${AMNEZIAWG_TOOLS_REF}" https://github.com/amnezia-vpn/amneziawg-tools.git /tmp/amneziawg-tools && \
     make -C /tmp/amneziawg-tools/src
 
 RUN mkdir /binaries && \

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import time
 import traceback as _traceback
 from typing import Dict, List, Optional
 
-from vpn_deck import BinaryManager, ConfigManager, ServiceManager
+from vpn_deck import BinaryManager, ConfigManager, Diagnostics, ServiceManager
 
 import decky
 
@@ -38,6 +38,9 @@ class Plugin:
         # Initialize ServiceManager
         self.service_manager = ServiceManager(self.binary_manager)
 
+        # Initialize Diagnostics
+        self.diagnostics = Diagnostics()
+
     def _add_error(self, operation: str, error_type: str, message: str, details: dict = None):
         """Добавляет ошибку в историю"""
         error = {
@@ -55,6 +58,14 @@ class Plugin:
     # Asyncio-compatible long-running code, executed in a task when the plugin is loaded
     async def _main(self):
         decky.logger.info("VPN Deck plugin initialized")
+        try:
+            repair = await self.config_manager.repair_symlinks()
+            if repair["repaired"]:
+                decky.logger.info(
+                    f"Auto-repaired {repair['repaired']}/{repair['total']} symlinks on startup"
+                )
+        except Exception as e:
+            decky.logger.error(f"Symlink auto-repair failed: {e}")
 
     # Function called first during the unload process, utilize this to handle your plugin being stopped, but not
     # completely removed
@@ -226,6 +237,21 @@ class Plugin:
         else:
             decky.logger.warning(f"Failed to delete config: {result.get('error')}")
         return result
+
+    @_rpc
+    async def repair_symlinks(self) -> dict:
+        """Re-creates missing symlinks in /etc/amnezia/amneziawg/ for all managed configs.
+
+        SteamOS updates reset /etc, so symlinks need to be rebuilt periodically.
+        """
+        result = await self.config_manager.repair_symlinks()
+        decky.logger.info(f"Symlink repair: {result['repaired']}/{result['total']} rebuilt")
+        return result
+
+    @_rpc
+    async def diagnose_connectivity(self, targets: Optional[List[Dict]] = None) -> List[Dict]:
+        """Runs ping/HTTP probes against default or custom targets."""
+        return self.diagnostics.check(targets)
 
     @_rpc
     async def get_vpn_config(self, name: str) -> Optional[str]:

--- a/py_modules/vpn_deck/__init__.py
+++ b/py_modules/vpn_deck/__init__.py
@@ -4,6 +4,7 @@ VPN Deck - Plugin modules
 
 from .binary_manager import BinaryManager
 from .config_manager import ConfigManager
+from .diagnostics import Diagnostics
 from .service_manager import ServiceManager
 
-__all__ = ['BinaryManager', 'ConfigManager', 'ServiceManager']
+__all__ = ['BinaryManager', 'ConfigManager', 'Diagnostics', 'ServiceManager']

--- a/py_modules/vpn_deck/_utils.py
+++ b/py_modules/vpn_deck/_utils.py
@@ -1,0 +1,22 @@
+"""Shared helpers used across vpn_deck modules."""
+
+import os
+from typing import Dict
+
+
+def clean_env() -> Dict[str, str]:
+    """Strips PyInstaller / Decky MEI paths from LD_LIBRARY_PATH.
+
+    Decky bundles the plugin runtime via PyInstaller, which injects
+    /tmp/_MEI* into LD_LIBRARY_PATH. Child processes like `awg-quick`,
+    `ping`, `curl` must not inherit these or they pick up bundled libs
+    that conflict with the system ones.
+    """
+    env = os.environ.copy()
+    if "LD_LIBRARY_PATH" in env:
+        paths = [p for p in env["LD_LIBRARY_PATH"].split(":") if "/tmp/" not in p and "_MEI" not in p]
+        if paths:
+            env["LD_LIBRARY_PATH"] = ":".join(paths)
+        else:
+            del env["LD_LIBRARY_PATH"]
+    return env

--- a/py_modules/vpn_deck/config_manager.py
+++ b/py_modules/vpn_deck/config_manager.py
@@ -153,6 +153,37 @@ class ConfigManager:
             decky.logger.error(f"Error reading config {config_path}: {e}")
             return None
     
+    def _ensure_symlink(self, local_path: str, system_path: str) -> Dict:
+        """Makes sure system_path is a symlink pointing at local_path.
+
+        Steam OS updates wipe /etc/amnezia/amneziawg/*, so this is called
+        both on import and on plugin load to repair links that slipped.
+        Returns {"ok": bool, "action": "none"|"created"|"replaced", "error": str|None}.
+        """
+        try:
+            os.makedirs(os.path.dirname(system_path), mode=0o755, exist_ok=True)
+
+            try:
+                if os.readlink(system_path) == local_path:
+                    return {"ok": True, "action": "none", "error": None}
+                existed = True
+            except OSError:
+                existed = os.path.lexists(system_path)
+
+            if existed:
+                try:
+                    os.unlink(system_path)
+                except FileNotFoundError:
+                    existed = False
+
+            os.symlink(local_path, system_path)
+            action = "replaced" if existed else "created"
+            decky.logger.info(f"Symlink {action}: {system_path} -> {local_path}")
+            return {"ok": True, "action": action, "error": None}
+        except Exception as e:
+            decky.logger.warning(f"Symlink failed for {system_path}: {e}")
+            return {"ok": False, "action": "error", "error": str(e)}
+
     def write_config(self, name: str, content: str) -> Dict:
         """Writes config to local store and creates symlink in system directory."""
         sanitized_name = self._sanitize_name(name)
@@ -165,16 +196,25 @@ class ConfigManager:
         os.chmod(local_path, 0o600)
         decky.logger.info(f"Wrote config to {local_path}")
 
-        try:
-            os.makedirs(self.system_config_dir, mode=0o755, exist_ok=True)
-            if os.path.exists(system_path) or os.path.islink(system_path):
-                os.unlink(system_path)
-            os.symlink(local_path, system_path)
-            decky.logger.info(f"Created symlink: {system_path} -> {local_path}")
-        except Exception as e:
-            decky.logger.warning(f"Symlink failed (non-fatal): {e}")
+        self._ensure_symlink(local_path, system_path)
 
         return {"success": True, "config_name": sanitized_name, "interface_name": interface_name, "error": None}
+
+    async def repair_symlinks(self) -> Dict:
+        """Re-creates missing/broken symlinks for all managed configs."""
+        scanned = await self.scan_existing_configs()
+        results = []
+        for cfg in scanned["managed"]:
+            r = self._ensure_symlink(cfg["path"], cfg["system_path"])
+            results.append({
+                "name": cfg["name"],
+                "interface": cfg["interface"],
+                "ok": r["ok"],
+                "action": r["action"],
+                "error": r["error"],
+            })
+        repaired = sum(1 for r in results if r["ok"] and r["action"] in ("created", "replaced"))
+        return {"total": len(results), "repaired": repaired, "results": results}
 
     async def delete_config(self, name: str) -> Dict:
         """Deletes a VPN configuration (no backup)."""

--- a/py_modules/vpn_deck/diagnostics.py
+++ b/py_modules/vpn_deck/diagnostics.py
@@ -1,0 +1,81 @@
+"""Diagnostics - connectivity probes for VPN troubleshooting."""
+
+import re
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, List, Optional
+
+import decky
+
+from ._utils import clean_env
+
+
+DEFAULT_TARGETS: List[Dict] = [
+    {"name": "1.1.1.1", "kind": "ping", "host": "1.1.1.1"},
+    {"name": "google.com", "kind": "http", "url": "https://www.google.com"},
+    {"name": "rutracker.org", "kind": "http", "url": "https://rutracker.org"},
+]
+
+
+class Diagnostics:
+    def check(self, targets: Optional[List[Dict]] = None) -> List[Dict]:
+        probes = targets if targets else DEFAULT_TARGETS
+        if not probes:
+            return []
+        with ThreadPoolExecutor(max_workers=len(probes)) as pool:
+            return list(pool.map(self._probe, probes))
+
+    def _probe(self, t: Dict) -> Dict:
+        kind = t.get("kind")
+        name = t.get("name") or t.get("host") or t.get("url") or "?"
+        if kind == "ping":
+            return self._ping(name, t["host"])
+        if kind == "http":
+            return self._http(name, t["url"])
+        return {"name": name, "kind": kind or "unknown", "ok": False, "detail": f"unknown kind: {kind}", "target": "", "latency_ms": None}
+
+    @staticmethod
+    def _ping(name: str, host: str) -> Dict:
+        try:
+            r = subprocess.run(
+                ["ping", "-c", "3", "-W", "2", "-n", host],
+                capture_output=True, text=True, timeout=12, check=False,
+                env=clean_env(),
+            )
+            ok = r.returncode == 0
+            avg_ms = None
+            if ok:
+                m = re.search(r"min/avg/max/\S+\s*=\s*[\d.]+/([\d.]+)/", r.stdout)
+                if m:
+                    avg_ms = float(m.group(1))
+            detail = f"avg {avg_ms:.1f} ms" if avg_ms is not None else (r.stderr.strip() or "no response")
+            return {"name": name, "kind": "ping", "target": host, "ok": ok, "detail": detail, "latency_ms": avg_ms}
+        except subprocess.TimeoutExpired:
+            return {"name": name, "kind": "ping", "target": host, "ok": False, "detail": "timeout", "latency_ms": None}
+        except FileNotFoundError:
+            decky.logger.warning("ping not found for diagnostics")
+            return {"name": name, "kind": "ping", "target": host, "ok": False, "detail": "ping not found", "latency_ms": None}
+
+    @staticmethod
+    def _http(name: str, url: str) -> Dict:
+        try:
+            r = subprocess.run(
+                ["curl", "-sS", "-o", "/dev/null", "-w", "%{http_code} %{time_total}",
+                 "--max-time", "6", "-L", url],
+                capture_output=True, text=True, timeout=10, check=False,
+                env=clean_env(),
+            )
+            out = r.stdout.strip()
+            parts = out.split()
+            code = parts[0] if parts else "0"
+            time_s = float(parts[1]) if len(parts) > 1 else None
+            ok = code.startswith(("2", "3"))
+            detail = f"HTTP {code}" + (f", {time_s:.2f}s" if time_s is not None else "")
+            if not ok and r.stderr:
+                detail += f" ({r.stderr.strip().splitlines()[-1]})"
+            return {"name": name, "kind": "http", "target": url, "ok": ok, "detail": detail, "latency_ms": time_s * 1000 if time_s else None}
+        except subprocess.TimeoutExpired:
+            return {"name": name, "kind": "http", "target": url, "ok": False, "detail": "timeout", "latency_ms": None}
+        except FileNotFoundError:
+            decky.logger.warning("curl not found for diagnostics")
+            return {"name": name, "kind": "http", "target": url, "ok": False, "detail": "curl not found", "latency_ms": None}

--- a/py_modules/vpn_deck/service_manager.py
+++ b/py_modules/vpn_deck/service_manager.py
@@ -8,6 +8,8 @@ from datetime import datetime
 
 import decky
 
+from ._utils import clean_env
+
 MANAGED_PREFIX = "vd-"
 DEFAULT_INTERFACE = "awg0"
 
@@ -20,18 +22,6 @@ class ServiceManager:
     def __init__(self, binary_manager):
         self.binary_manager = binary_manager
 
-    @staticmethod
-    def _clean_env() -> dict:
-        env = os.environ.copy()
-        if 'LD_LIBRARY_PATH' in env:
-            paths = env['LD_LIBRARY_PATH'].split(':')
-            paths = [p for p in paths if '/tmp/' not in p and '_MEI' not in p]
-            if paths:
-                env['LD_LIBRARY_PATH'] = ':'.join(paths)
-            else:
-                del env['LD_LIBRARY_PATH']
-        return env
-
     def _run(self, cmd: list, timeout: int = 10, quiet: bool = False):
         log = decky.logger.debug if quiet else decky.logger.info
         log(f"Running: {' '.join(str(c) for c in cmd)}")
@@ -41,7 +31,7 @@ class ServiceManager:
                 capture_output=True,
                 text=True,
                 timeout=timeout,
-                env=self._clean_env()
+                env=clean_env()
             )
             return (result.returncode, result.stdout.strip(), result.stderr.strip())
         except subprocess.TimeoutExpired:
@@ -73,7 +63,7 @@ class ServiceManager:
                     text=True,
                     timeout=timeout,
                     start_new_session=True,
-                    env=self._clean_env(),
+                    env=clean_env(),
                 )
                 log_file.write(f"--- RC: {result.returncode} ---\n")
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,7 @@ import {
   openFilePicker,
   toaster,
 } from "@decky/api";
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { FaNetworkWired } from "react-icons/fa";
 
 interface VPNError {
@@ -65,9 +65,37 @@ const deleteVpnConfig = callable<[{ name: string }] | [string], DeleteConfigResu
   "delete_vpn_config"
 );
 
+interface SymlinkRepairItem {
+  name: string;
+  interface: string;
+  ok: boolean;
+  action: "none" | "created" | "replaced" | "error";
+  error: string | null;
+}
+interface SymlinkRepairResult {
+  total: number;
+  repaired: number;
+  results: SymlinkRepairItem[];
+}
+const repairSymlinks = callable<[], SymlinkRepairResult>("repair_symlinks");
+
+interface DiagnosticsProbe {
+  name: string;
+  kind: "ping" | "http";
+  target: string;
+  ok: boolean;
+  detail: string;
+  latency_ms: number | null;
+}
+const diagnoseConnectivity = callable<[], DiagnosticsProbe[]>("diagnose_connectivity");
+
 // Валидация имени конфига: как в awg-quick и config_manager (интерфейс = vd-<name>, макс. 15 символов)
 const CONFIG_NAME_MAX_LEN = 12; // 3 (префикс "vd-") + 12 = 15
 const CONFIG_NAME_REGEX = /^[a-zA-Z0-9_=+.-]+$/;
+
+function formatTimestamp(timestamp: number): string {
+  return new Date(timestamp * 1000).toLocaleString();
+}
 
 function validateConfigName(name: string): { valid: boolean; error?: string } {
   const trimmed = name.trim();
@@ -111,8 +139,6 @@ function ImportConfigModal({
         undefined,
         ["conf"],
       );
-      console.log(res);
-      console.trace("after pick");
       const filename =
         res.realpath
           .split("/")
@@ -256,12 +282,9 @@ function Content() {
   const [loadingMap, setLoadingMap] = useState<Record<string, boolean>>({});
   const [errors, setErrors] = useState<VPNError[]>([]);
   const [showErrors, setShowErrors] = useState<boolean>(false);
-  const pollingRef = useRef<NodeJS.Timeout | null>(null);
-  const errorsPollingRef = useRef<NodeJS.Timeout | null>(null);
-
-  const formatTimestamp = (timestamp: number): string => {
-    return new Date(timestamp * 1000).toLocaleString();
-  };
+  const [probes, setProbes] = useState<DiagnosticsProbe[] | null>(null);
+  const [probesLoading, setProbesLoading] = useState<boolean>(false);
+  const [repairLoading, setRepairLoading] = useState<boolean>(false);
 
   const refreshConfigs = useCallback(async () => {
     try {
@@ -315,7 +338,40 @@ function Content() {
     [refreshConfigs, loadErrors],
   );
 
-  const handleClearErrors = async () => {
+  const handleDiagnose = useCallback(async () => {
+    setProbesLoading(true);
+    try {
+      const res = await diagnoseConnectivity();
+      setProbes(res);
+      const ok = res.filter((p) => p.ok).length;
+      toaster.toast({
+        title: "Проверка связи",
+        body: `${ok}/${res.length} доступно`,
+      });
+    } catch (e) {
+      toaster.toast({ title: "Ошибка диагностики", body: String(e) });
+    } finally {
+      setProbesLoading(false);
+    }
+  }, []);
+
+  const handleRepairSymlinks = useCallback(async () => {
+    setRepairLoading(true);
+    try {
+      const res = await repairSymlinks();
+      toaster.toast({
+        title: "Симлинки",
+        body: `Восстановлено ${res.repaired} из ${res.total}`,
+      });
+      await refreshConfigs();
+    } catch (e) {
+      toaster.toast({ title: "Ошибка восстановления", body: String(e) });
+    } finally {
+      setRepairLoading(false);
+    }
+  }, [refreshConfigs]);
+
+  const handleClearErrors = useCallback(async () => {
     try {
       await clearErrors();
       setErrors([]);
@@ -323,18 +379,18 @@ function Content() {
     } catch (error) {
       toaster.toast({ title: "Ошибка очистки", body: String(error) });
     }
-  };
+  }, []);
 
   useEffect(() => {
     refreshConfigs();
     loadErrors();
 
-    pollingRef.current = setInterval(refreshConfigs, 3000);
-    errorsPollingRef.current = setInterval(loadErrors, 10000);
+    const configsInterval = setInterval(refreshConfigs, 3000);
+    const errorsInterval = setInterval(loadErrors, 10000);
 
     return () => {
-      if (pollingRef.current) clearInterval(pollingRef.current);
-      if (errorsPollingRef.current) clearInterval(errorsPollingRef.current);
+      clearInterval(configsInterval);
+      clearInterval(errorsInterval);
     };
   }, [refreshConfigs, loadErrors]);
 
@@ -386,6 +442,45 @@ function Content() {
         </PanelSectionRow>
       </PanelSection>
 
+      <PanelSection title="Диагностика">
+        <PanelSectionRow>
+          <ButtonItem
+            layout="below"
+            disabled={probesLoading}
+            onClick={handleDiagnose}
+          >
+            {probesLoading ? "Проверка…" : "Проверить связь"}
+          </ButtonItem>
+        </PanelSectionRow>
+        {probes && probes.map((p, i) => (
+          <PanelSectionRow key={`${p.name}-${i}`}>
+            <div
+              style={{
+                padding: "8px",
+                fontSize: "12px",
+                borderLeft: `3px solid ${p.ok ? "#4ade80" : "#f87171"}`,
+                paddingLeft: "10px",
+                marginBottom: "4px",
+              }}
+            >
+              <div style={{ fontWeight: "bold" }}>
+                {p.ok ? "✓" : "✗"} {p.name}
+              </div>
+              <div style={{ color: "#8b929a" }}>{p.detail}</div>
+            </div>
+          </PanelSectionRow>
+        ))}
+        <PanelSectionRow>
+          <ButtonItem
+            layout="below"
+            disabled={repairLoading}
+            onClick={handleRepairSymlinks}
+          >
+            {repairLoading ? "Восстановление…" : "Восстановить симлинки"}
+          </ButtonItem>
+        </PanelSectionRow>
+      </PanelSection>
+
       <PanelSection title="Ошибки">
         <PanelSectionRow>
           <ButtonItem
@@ -428,8 +523,8 @@ function Content() {
               errors
                 .slice()
                 .reverse()
-                .map((error, index) => (
-                  <PanelSectionRow key={index}>
+                .map((error) => (
+                  <PanelSectionRow key={`${error.timestamp}-${error.operation}`}>
                     <div
                       style={{
                         padding: "12px",


### PR DESCRIPTION
Previously `git clone --depth 1` pulled HEAD of master at build time, so
the bundled binary version depended on when the release was built. AWG
2.0 support (ranged H1-H4, S3-S4 junks, I1-I5 concealment) landed in
amneziawg-go v0.2.15 and amneziawg-tools v1.0.20250901 (both Sep 2025).
Builds made before that silently drop the new config keys — handshake
succeeds but transport packets get rejected, which matches the symptom
reported in issue #3.

Pin both to the latest stable tags so subsequent releases are
reproducible and ship AWG 2.0 support:
- amneziawg-go v0.2.17 (31 Mar 2026)
- amneziawg-tools v1.0.20260223 (23 Feb 2026)

Refs #3